### PR TITLE
Add Selenium tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
 language: java
+
 jdk:
   - oraclejdk8
+
+script:
+  - ./gradlew check
+  - ./gradlew seleniumXvfb

--- a/bin/xvfb
+++ b/bin/xvfb
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+  echo "`basename $0` {start|stop}"
+  exit
+fi
+
+case "$1" in
+start)
+  /usr/bin/Xvfb :99 -ac -screen 0 1024x768x8 &
+;;
+stop)
+  killall Xvfb
+;;
+esac

--- a/build.gradle
+++ b/build.gradle
@@ -47,3 +47,9 @@ task seleniumXvfb(type: Test, dependsOn: installDist) {
         'sh -e /etc/init.d/xvfb stop'.execute()
     }
 }
+
+test {
+    testLogging {
+        exceptionFormat = 'full'
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -7,11 +7,43 @@ repositories {
     jcenter()
 }
 
+sourceSets {
+    selenium
+    seleniumXvfb
+}
+
 dependencies {
     compile 'org.slf4j:slf4j-api:1.7.5'
+    compile 'net.joningi:icndb-java-api:1.0'
+    compile 'com.sparkjava:spark-core:2.3'
 
     testCompile 'junit:junit:4.11'
 
-    compile 'net.joningi:icndb-java-api:1.0'
-    compile 'com.sparkjava:spark-core:2.3'
+
+    seleniumCompile 'junit:junit:4.11'
+    seleniumCompile 'org.seleniumhq.selenium:selenium-java:2.48.2'
+
+    seleniumXvfbCompile 'junit:junit:4.11'
+    seleniumXvfbCompile 'org.seleniumhq.selenium:selenium-java:2.48.2'
+}
+
+task selenium(type: Test, dependsOn: installDist) {
+    testClassesDir = sourceSets.selenium.output.classesDir
+    classpath = sourceSets.selenium.runtimeClasspath
+}
+
+task seleniumXvfb(type: Test, dependsOn: installDist) {
+    testClassesDir = sourceSets.selenium.output.classesDir
+    classpath = sourceSets.selenium.runtimeClasspath
+
+    environment "DISPLAY", ":99"
+
+    doFirst {
+        'bin/xvfb start'.execute()
+        'build/install/chuck_joke/bin/chuck_joke &'.execute()
+    }
+
+    doLast {
+        'sh -e /etc/init.d/xvfb stop'.execute()
+    }
 }

--- a/src/main/java/is/ru/arnlaugsson/chuck_joke/Chuck.java
+++ b/src/main/java/is/ru/arnlaugsson/chuck_joke/Chuck.java
@@ -28,4 +28,8 @@ public class Chuck {
         client.setFirstName(firstName);
         client.setLastName(lastName);
     }
+
+    public void resetName() {
+        client.clearName();
+    }
 }

--- a/src/main/java/is/ru/arnlaugsson/chuck_joke/ChuckWeb.java
+++ b/src/main/java/is/ru/arnlaugsson/chuck_joke/ChuckWeb.java
@@ -32,6 +32,11 @@ public class ChuckWeb implements SparkApplication {
             res.status(200);
             return res;
         });
+        get("/resetName", (req, res) -> {
+            chuck.resetName();
+            res.status(200);
+            return res;
+        });
     }
 
 }

--- a/src/selenium/java/is/ru/arnlaugsson/chuck_joke/ChuckWebTest.java
+++ b/src/selenium/java/is/ru/arnlaugsson/chuck_joke/ChuckWebTest.java
@@ -1,0 +1,98 @@
+package is.arnlaugsson.chuck_joke;
+
+import java.util.concurrent.TimeUnit;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.AfterClass;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.support.ui.*;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+
+public class ChuckWebTest {
+
+    static WebDriver driver;
+    static String baseUrl;
+    static String port;
+
+    @BeforeClass
+    public static void before() {
+        driver = new FirefoxDriver();
+        port = System.getenv("PORT");
+        if(port == null) {
+            port = "4567";
+        }
+        baseUrl = "http://localhost:" + port;
+        driver.manage().timeouts().implicitlyWait(30, TimeUnit.SECONDS);
+    }
+
+    @AfterClass
+    public static void after() {
+        driver.close();
+    }
+
+    @Before
+    public void setup() {
+        ;
+    }
+
+    @After
+    public void tearDown() {
+        driver.get(baseUrl + "/resetName");
+    }
+
+    @Test
+    public void assertTitle() {
+        driver.get(baseUrl + "/");
+        assertEquals("Chuck Norris Jokes", driver.getTitle());
+    }
+
+    @Test
+    public void assertSpecificJoke() {
+        driver.get(baseUrl + "/specific.html");
+
+        WebElement number = driver.findElement(By.id("number"));
+        number.clear();
+        number.sendKeys("5");
+
+        driver.findElement(By.cssSelector("button[type=\"submit\"]")).click();
+        WebDriverWait wait = new WebDriverWait(driver, 10);
+        WebElement updatedBox = wait.until(
+            ExpectedConditions.visibilityOfElementLocated(By.cssSelector(".alert-success")));
+        String expected = "Chuck Norris lost his virginity before his dad did.";
+        String found = driver.findElement(By.id("results")).getText();
+        assertEquals(expected, found);
+    }
+
+    @Test
+    public void assertThatChangedNameIsUsed() {
+        driver.get(baseUrl + "/config.html");
+
+        WebElement firstName = driver.findElement(By.id("firstName"));
+        firstName.clear();
+        firstName.sendKeys("Hannes");
+
+        WebElement lastName = driver.findElement(By.id("lastName"));
+        lastName.clear();
+        lastName.sendKeys("Pétursson");
+
+        driver.findElement(By.cssSelector("button[type=\"submit\"]")).click();
+        driver.get(baseUrl + "/specific.html");
+
+        WebElement number = driver.findElement(By.id("number"));
+        number.clear();
+        number.sendKeys("396");
+
+        driver.findElement(By.cssSelector("button[type=\"submit\"]")).click();
+        WebDriverWait wait = new WebDriverWait(driver, 10);
+        String expected = "Only Hannes Pétursson can prevent forest fires.";
+        String found = driver.findElement(By.id("results")).getText();
+    }
+}


### PR DESCRIPTION
# Selenium coverage
## This PR adds two important things
1. The ability to run Selenium tests in Xvfb (headless) manner on servers (such as on Travis CI) and on the Advania QStack servers (Ubuntu 14.04 servers).
2. Three non trivial Selenium functional tests for the Chuck Joke Web app:
   - `assertTitle()` - asserts the web application is up and running by asserting the title of the page is correct.
   - `assertSpecificJoke()` - asserts that the web app can deliver an expected joke on cue.
   - `assertThatChangedNameIsUsed()` - asserts that the web app can be configured to use a different name (other than "Chuck Norris"), and that the jokes shown will use the name given.
